### PR TITLE
fix: resolve perpetual diff and duplicate objects when use_object_id is true

### DIFF
--- a/pkg/resources/tml.go
+++ b/pkg/resources/tml.go
@@ -211,7 +211,7 @@ func exportTml(ctx context.Context, client *thoughtspot.Client, id string, tml s
 		EdocFormat: "YAML",
 		ExportOptions: models.ExportOptions{
 			IncludeGuid:  !useObjectId,
-			IncludeObjId: useObjectId,
+			IncludeObjId: false,
 		},
 	}
 
@@ -225,14 +225,6 @@ func exportTml(ctx context.Context, client *thoughtspot.Client, id string, tml s
 	}
 
 	if len(c) == 0 {
-		return nil, diags
-	}
-
-	if c[0].Info.Status.StatusCode == "ERROR" {
-		diags.AddError(
-			"Error reading TML",
-			"Could not read tml , unexpected error: "+c[0].Info.Status.ErrorMessage,
-		)
 		return nil, diags
 	}
 
@@ -276,6 +268,14 @@ func exportTml(ctx context.Context, client *thoughtspot.Client, id string, tml s
 		}
 		guids = append(guids, guid)
 
+	}
+
+	// When using object IDs, the ThoughtSpot API export may omit fields that are present in
+	// the user's config (e.g. fqn) or add fields that are not (e.g. obj_id). To avoid
+	// perpetual diffs, store the config TML directly in state — the API response is only
+	// used to obtain the resource id and name.
+	if useObjectId {
+		tmlExport = tml
 	}
 
 	lg, diag := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: MetadataGuidModel{}.attrTypes()}, guids)
@@ -407,6 +407,13 @@ func (r *TmlResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	for _, guid := range guids {
 		tml = strings.Replace(tml, guid.Original.ValueString(), guid.Computed.ValueString(), 1)
 
+	}
+
+	// When use_object_id is true, the config TML has no guid or obj_id identifiers.
+	// Inject the resource's guid so ThoughtSpot can identify the existing object to update,
+	// preventing it from creating a duplicate object instead.
+	if plan.UseObjectId.ValueBool() {
+		tml = "guid: " + plan.ID.ValueString() + "\n" + tml
 	}
 
 	cr := models.ImportMetadataTMLRequest{


### PR DESCRIPTION
**Problem**
Described here: https://github.com/daniepett/terraform-provider-thoughtspot/issues/3

**Fix**
- Export: Set `IncludeObjId: false`. The API response is only used to obtain the resource id and name; the TML content itself is unreliable for state comparison when `use_object_id = true`.
- Read/state: When `use_object_id = true`, store the config TML directly in state. This guarantees state always matches the plan, regardless of what the API injects or omits.
- Update: Prepend `guid: <resource-id>` to the submitted TML so ThoughtSpot can identify and update the existing object rather than creating a duplicate.

**Testing**
Tested against a live ThoughtSpot instance with tables and models using `use_object_id = true`:
- Terraform plan returns no changes after initial apply
- Terraform apply updates existing objects in place, no duplicates created


Before:
<img width="1210" height="914" alt="image" src="https://github.com/user-attachments/assets/533111df-af28-4e97-b384-8de5d611152a" />


After:
<img width="1210" height="859" alt="image" src="https://github.com/user-attachments/assets/9882e0de-fdc3-46e5-8bab-15b6b8db2d86" />
